### PR TITLE
Update mix.exs to include source_url

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule Rot13.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
+      source_url: "https://github.com/jdenen/rot13",
       description: "A rot13 cipher library"
     ]
   end


### PR DESCRIPTION
This lets ex_doc link back to the source from the docs